### PR TITLE
neovim-lsp

### DIFF
--- a/vim-config/.vim/plugins/nvim-mappings.vim
+++ b/vim-config/.vim/plugins/nvim-mappings.vim
@@ -1,0 +1,84 @@
+"=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+" These are example settings to use with nvim-metals and the nvim built in
+" LSP.  Be sure to thoroughly read the the help docs to get an idea of what
+" everything does.
+"
+" The below configuration also makes use of the following plugins besides
+" nvim-metals
+" - https://github.com/nvim-lua/completion-nvim
+"=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+
+"-----------------------------------------------------------------------------
+" nvim-lsp Mappings
+"-----------------------------------------------------------------------------
+nnoremap <silent> gd          <cmd>lua vim.lsp.buf.definition()<CR>
+nnoremap <silent> K           <cmd>lua vim.lsp.buf.hover()<CR>
+nnoremap <silent> gi          <cmd>lua vim.lsp.buf.implementation()<CR>
+nnoremap <silent> gr          <cmd>lua vim.lsp.buf.references()<CR>
+nnoremap <silent> gds         <cmd>lua vim.lsp.buf.document_symbol()<CR>
+nnoremap <silent> gws         <cmd>lua vim.lsp.buf.workspace_symbol()<CR>
+nnoremap <silent> <leader>rn  <cmd>lua vim.lsp.buf.rename()<CR>
+nnoremap <silent> <leader>f   <cmd>lua vim.lsp.buf.formatting()<CR>
+nnoremap <silent> <leader>a  <cmd>lua vim.lsp.buf.code_action()<CR>
+nnoremap <silent> <leader>ws  <cmd>lua require'metals'.worksheet_hover()<CR>
+"nnoremap <silent> <leader>A   <cmd>lua require'metals'.open_all_diagnostics()<CR>
+nnoremap <silent> <space>d    <cmd>lua vim.lsp.diagnostic.set_loclist()<CR>
+nnoremap <silent> [c          <cmd>lua vim.lsp.diagnostic.goto_prev { wrap = false }<CR>
+nnoremap <silent> ]c          <cmd>lua vim.lsp.diagnostic.goto_next { wrap = false }<CR>
+
+"-----------------------------------------------------------------------------
+" nvim-lsp Settings
+"-----------------------------------------------------------------------------
+" If you just use the latest stable version, then setting this isn't necessary
+"let g:metals_server_version = '0.9.8+10-334e402e-SNAPSHOT'
+
+"-----------------------------------------------------------------------------
+" nvim-metals setup with a few additions such as nvim-completions
+"-----------------------------------------------------------------------------
+:lua << EOF
+  metals_config = require'metals'.bare_config()
+  metals_config.settings = {
+     showImplicitArguments = true,
+     excludedPackages = {
+       "akka.actor.typed.javadsl",
+       "com.github.swagger.akka.javadsl"
+     }
+  }
+
+  metals_config.on_attach = function()
+    require'completion'.on_attach();
+  end
+
+  metals_config.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
+    vim.lsp.diagnostic.on_publish_diagnostics, {
+      virtual_text = {
+        prefix = '',
+      }
+    }
+  )
+  require'lspconfig'.hls.setup{}
+
+
+EOF
+
+if has('nvim-0.6')
+  augroup lsp
+    au!
+    au FileType scala,sbt lua require('metals').initialize_or_attach(metals_config)
+  augroup end
+endif
+
+"-----------------------------------------------------------------------------
+" completion-nvim settings
+"-----------------------------------------------------------------------------
+" Use <Tab> and <S-Tab> to navigate through popup menu
+inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
+inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
+
+"-----------------------------------------------------------------------------
+" Helpful general settings
+"-----------------------------------------------------------------------------
+" Needed for compltions _only_ if you aren't using completion-nvim
+autocmd FileType scala setlocal omnifunc=v:lua.vim.lsp.omnifunc
+
+

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -105,8 +105,6 @@ endtry
 
 call plug#begin('~/.vim/bundle')
 Plug 'nanotech/jellybeans.vim'
-"Plug 'neoclide/coc.nvim', {'branch': 'release'}
-" Plug 'udalov/kotlin-vim'
 " Haskell formatter on save (assuming ormolu is installed in the system)
 Plug 'sdiehl/vim-ormolu'
 
@@ -126,33 +124,11 @@ Plug 'neovim/nvim-lspconfig'
 
 call plug#end()
 
-" Find files using Telescope command-line sugar.
-nnoremap <leader>ff <cmd> Telescope find_files<cr>
-nnoremap <leader>fg <cmd>Telescope live_grep<cr>
-nnoremap <leader>fb <cmd>Telescope buffers<cr>
-nnoremap <leader>fh <cmd>Telescope help_tags<cr>
-
-
-" Setup fuzzy finder fzf bridge (requires fzf installed)
-" set rtp+=/usr/local/opt/fzf
-" nnoremap <silent> <Leader>ff :GFiles --cached --others --exclude-standard<CR>
-" nnoremap <silent> <Leader>fg :Rg<CR>
-" nnoremap <silent> <Leader>fb :Buffers<CR>
-
 " Comments highlighting when using jsonc as configuration file format
 autocmd FileType json syntax match Comment +\/\/.\+$+
 
 " Help Vim recognize *.sbt and *.sc as Scala files
 au BufRead,BufNewFile *.sbt,*.sc,*.scala set filetype=scala
-
-" ===== Load plugin specific configuration ====
-"if filereadable(expand("~/.vim/plugins/coc-mappings.vim"))
-"   source ~/.vim/plugins/coc-mappings.vim
-"endif
-
-if filereadable(expand("~/.vim/plugins/nvim-mappings.vim"))
-   source ~/.vim/plugins/nvim-mappings.vim
-endif
 
 " Remove trailing spaces on save
 fun s:StripTrailingWhitespaces()
@@ -189,29 +165,46 @@ augroup END
 noremap <silent> <Leader>cc :<C-B>silent <C-E>s/^/<C-R>=escape(b:comment_leader,'\/')<CR>/<CR>:nohlsearch<CR>
 noremap <silent> <Leader>cu :<C-B>silent <C-E>s/^\V<C-R>=escape(b:comment_leader,'\/')<CR>//e<CR>:nohlsearch<CR>
 
+" neovim settings (they require lua, or plugins only available for neovim)
 
-let g:compe = {}
-let g:compe.enabled = v:true
-let g:compe.autocomplete = v:true
-let g:compe.debug = v:false
-let g:compe.min_length = 1
-let g:compe.preselect = 'enable'
-let g:compe.throttle_time = 80
-let g:compe.source_timeout = 200
-let g:compe.resolve_timeout = 800
-let g:compe.incomplete_delay = 400
-let g:compe.max_abbr_width = 100
-let g:compe.max_kind_width = 100
-let g:compe.max_menu_width = 100
-let g:compe.documentation = v:true
+if has('nvim')
 
-let g:compe.source = {}
-let g:compe.source.path = v:true
-let g:compe.source.buffer = v:true
-let g:compe.source.calc = v:true
-let g:compe.source.nvim_lsp = v:true
-let g:compe.source.nvim_lua = v:true
-let g:compe.source.vsnip = v:true
-let g:compe.source.ultisnips = v:true
-let g:compe.source.luasnip = v:true
-let g:compe.source.emoji = v:true
+  if filereadable(expand("~/.vim/plugins/nvim-mappings.vim"))
+    source ~/.vim/plugins/nvim-mappings.vim
+  endif
+
+  " Find files using Telescope command-line sugar.
+  nnoremap <leader>ff <cmd> Telescope find_files<cr>
+  nnoremap <leader>fg <cmd>Telescope live_grep<cr>
+  nnoremap <leader>fb <cmd>Telescope buffers<cr>
+  nnoremap <leader>fh <cmd>Telescope help_tags<cr>
+
+
+  " nvim-compe settings
+  let g:compe = {}
+  let g:compe.enabled = v:true
+  let g:compe.autocomplete = v:true
+  let g:compe.debug = v:false
+  let g:compe.min_length = 1
+  let g:compe.preselect = 'enable'
+  let g:compe.throttle_time = 80
+  let g:compe.source_timeout = 200
+  let g:compe.resolve_timeout = 800
+  let g:compe.incomplete_delay = 400
+  let g:compe.max_abbr_width = 100
+  let g:compe.max_kind_width = 100
+  let g:compe.max_menu_width = 100
+  let g:compe.documentation = v:true
+
+  let g:compe.source = {}
+  let g:compe.source.path = v:true
+  let g:compe.source.buffer = v:true
+  let g:compe.source.calc = v:true
+  let g:compe.source.nvim_lsp = v:true
+  let g:compe.source.nvim_lua = v:true
+  let g:compe.source.vsnip = v:true
+  let g:compe.source.ultisnips = v:true
+  let g:compe.source.luasnip = v:true
+  let g:compe.source.emoji = v:true
+
+endif

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -30,7 +30,7 @@ if has("statusline")
 endif
 
 " no statusbar by default (0 = never, 2 = always)
-set laststatus=0
+" set laststatus=0
 
 " Don’t add empty newlines at the end of files
 set noeol
@@ -39,11 +39,11 @@ set noeol
 set secure
 
 " Don't show the cursor position
-set noruler
+" set noruler
 
 " Don't show line number. If you turn it on, consider relative numbers:
 " set number relativenumber
-set nonumber
+" set nonumber
 
 " Disable error bells
 set noerrorbells
@@ -76,12 +76,21 @@ set nohlsearch
 " Do not change cursor shape in insert mode (to fix neovim standard behaviour)
 set guicursor=
 
+" Set completeopt to have a better completion experience
+set completeopt=menuone,noinsert,noselect
+
+" Avoid showing message extra message when using completion
+set shortmess+=c
+
+" Ensure autocmd works for Filetype
+set shortmess-=F
+
 " Default colorscheme (has to be installed, see vim-plug below)
 " You need ot generate a symb link in .vim/colors folder
 " ln -s ~/.vim/bundle/jellybeans.vim/colors/jellybeans.vim ~/.vim/colors/jellybeans.vim
 set termguicolors     " enable true colors support
 try
-  colorscheme jellybeans
+   colorscheme jellybeans
 catch /^Vim\%((\a\+)\)\=:E185/
 endtry
 
@@ -96,22 +105,39 @@ endtry
 
 call plug#begin('~/.vim/bundle')
 Plug 'nanotech/jellybeans.vim'
-
-Plug 'neoclide/coc.nvim', {'branch': 'release'}
-Plug 'udalov/kotlin-vim'
+"Plug 'neoclide/coc.nvim', {'branch': 'release'}
+" Plug 'udalov/kotlin-vim'
 " Haskell formatter on save (assuming ormolu is installed in the system)
 Plug 'sdiehl/vim-ormolu'
 
-Plug 'junegunn/fzf', {'dir': '~/.fzf','do': './install --all'}
-Plug 'junegunn/fzf.vim' " needed for previews
+" Plug 'junegunn/fzf', {'dir': '~/.fzf','do': './install --all'}
+" Plug 'junegunn/fzf.vim' " needed for previews
 
 Plug 'tpope/vim-surround'
 Plug 'tpope/vim-repeat'
 
+Plug 'nvim-lua/plenary.nvim'
+Plug 'nvim-telescope/telescope.nvim'
+
+Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}  " We recommend updating the parsers on update
+Plug 'scalameta/nvim-metals'
+Plug 'hrsh7th/nvim-compe'
+Plug 'neovim/nvim-lspconfig'
+
 call plug#end()
 
+" Find files using Telescope command-line sugar.
+nnoremap <leader>ff <cmd> Telescope find_files<cr>
+nnoremap <leader>fg <cmd>Telescope live_grep<cr>
+nnoremap <leader>fb <cmd>Telescope buffers<cr>
+nnoremap <leader>fh <cmd>Telescope help_tags<cr>
+
+
 " Setup fuzzy finder fzf bridge (requires fzf installed)
-set rtp+=/usr/local/opt/fzf
+" set rtp+=/usr/local/opt/fzf
+" nnoremap <silent> <Leader>ff :GFiles --cached --others --exclude-standard<CR>
+" nnoremap <silent> <Leader>fg :Rg<CR>
+" nnoremap <silent> <Leader>fb :Buffers<CR>
 
 " Comments highlighting when using jsonc as configuration file format
 autocmd FileType json syntax match Comment +\/\/.\+$+
@@ -120,8 +146,12 @@ autocmd FileType json syntax match Comment +\/\/.\+$+
 au BufRead,BufNewFile *.sbt,*.sc,*.scala set filetype=scala
 
 " ===== Load plugin specific configuration ====
-if filereadable(expand("~/.vim/plugins/coc-mappings.vim"))
-   source ~/.vim/plugins/coc-mappings.vim
+"if filereadable(expand("~/.vim/plugins/coc-mappings.vim"))
+"   source ~/.vim/plugins/coc-mappings.vim
+"endif
+
+if filereadable(expand("~/.vim/plugins/nvim-mappings.vim"))
+   source ~/.vim/plugins/nvim-mappings.vim
 endif
 
 " Remove trailing spaces on save
@@ -134,10 +164,6 @@ endfun
 autocmd FileType sh,scala,kotlin,json autocmd BufWritePre <buffer> :call <SID>StripTrailingWhitespaces()
 command! StripTrailingWhitespaces call s:StripTrailingWhitespaces()
 
-nnoremap <silent> <Leader>f :GFiles --cached --others --exclude-standard<CR>
-nnoremap <silent> <Leader>g :Rg<CR>
-nnoremap <silent> <Leader>b :Buffers<CR>
-
 " Persist undo
 if !isdirectory($HOME."/.vim")
     call mkdir($HOME."/.vim", "", 0770)
@@ -148,7 +174,7 @@ endif
 set undodir=~/.vim/undo-dir
 set undofile
 
-" Mapping to comment lines
+" comment selected lines
 " source: https://stackoverflow.com/questions/1676632/whats-a-quick-way-to-comment-uncomment-lines-in-vim
 augroup commenting_blocks_of_code
   autocmd!
@@ -162,3 +188,30 @@ augroup commenting_blocks_of_code
 augroup END
 noremap <silent> <Leader>cc :<C-B>silent <C-E>s/^/<C-R>=escape(b:comment_leader,'\/')<CR>/<CR>:nohlsearch<CR>
 noremap <silent> <Leader>cu :<C-B>silent <C-E>s/^\V<C-R>=escape(b:comment_leader,'\/')<CR>//e<CR>:nohlsearch<CR>
+
+
+let g:compe = {}
+let g:compe.enabled = v:true
+let g:compe.autocomplete = v:true
+let g:compe.debug = v:false
+let g:compe.min_length = 1
+let g:compe.preselect = 'enable'
+let g:compe.throttle_time = 80
+let g:compe.source_timeout = 200
+let g:compe.resolve_timeout = 800
+let g:compe.incomplete_delay = 400
+let g:compe.max_abbr_width = 100
+let g:compe.max_kind_width = 100
+let g:compe.max_menu_width = 100
+let g:compe.documentation = v:true
+
+let g:compe.source = {}
+let g:compe.source.path = v:true
+let g:compe.source.buffer = v:true
+let g:compe.source.calc = v:true
+let g:compe.source.nvim_lsp = v:true
+let g:compe.source.nvim_lua = v:true
+let g:compe.source.vsnip = v:true
+let g:compe.source.ultisnips = v:true
+let g:compe.source.luasnip = v:true
+let g:compe.source.emoji = v:true


### PR DESCRIPTION
* remove Coc plugins (this will eventually allow to remove globally installed node server) 
* install nvim-metals 
* install nvim-config 
* install nvim-compe + settings 
* use telescope instead of fzf plugin 
* new nvim-mappingvim file with configuration for metals and hls (in lua, so incompatible with vim) 

Since all these changes, ie, 
* usage of neovim **built-in** LSP 
* usage of telescope 

will make neovim config definitely incompatible with vim, the setup cannot be shared with vim anymore, otherwise we get errors like 
```
line    6:
E319: Sorry, the command is not available in this version: lua << EOF
```

I have to think what to do (stop having shared config with vim?). I've already wrapped some of the code inside a `if has('nvim')` but that's not enough for plugins 