### PR TITLE
Tmux: mouse off and mode-keys: vi

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -9,10 +9,13 @@ set -g default-command "${SHELL}"
 set -g history-limit 30000
 
 # Make mouse useful again
-setw -g mouse on
+setw -g mouse off
 
 # Disable status bar
 set -g status off
+
+# Use vim mode, no emacs mode
+set -g mode-keys vi
 
 # can improve cursor responsiveness and fix issues with autoread in neovim
 set-option -g focus-events on


### PR DESCRIPTION
Tmux mouse selection is too awkward. For instance, sometimes ut feels “off by one” (either grabbing an extra character or failing to include the last character). Let's disable the propagation of mouse events to tmux, so i can have alacritty native selection (which is smooth). 

The downside is that now search and scrolling need to be done via tmux key presses, so let's set vi key bindings instead of default emacs ones 