### PR TITLE
remove delta from gitconfig, add delta autocompletion

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -201,6 +201,9 @@ export PKG_CONFIG_PATH="/opt/homebrew/opt/zlib/lib/pkgconfig"
 [ -f "/Users/alessandrocandolini/.ghcup/env" ] && source "/Users/alessandrocandolini/.ghcup/env" # ghcup-env
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 
+if command -v delta >/dev/null; then
+  eval "$(delta --generate-completion bash)"
+fi
 
 export PATH=/Applications/IntelliJ\ IDEA\ CE.app/Contents/MacOS:$PATH
 

--- a/gitconfig/.gitconfig
+++ b/gitconfig/.gitconfig
@@ -1,14 +1,9 @@
 [core]
   excludesfile = ~/.gitignore
-  pager = delta
-
-[interactive]
-  diffFilter = delta --color-only
 
 [delta]
   navigate = true  # use n and N to move between diff sections
   dark = true      # or light = true, or omit for auto-detection
-  side-by-side = true
   line-numbers = true
 
 [merge]


### PR DESCRIPTION
I'm not entirely sure whether `delta` interferes with `git add -p` (see https://github.com/dandavison/delta/issues/1650), and I still need to determine which default options work best for me. Given this, I believe it's best, at least for now, to remove `delta` as the default pager and, more importantly, as the default `diffFilter`. If needed, I can still use it explicitly via:

> git diff | delta 
gh pr diff | delta

Since I’ll be removing most default options (except enabling line numbers), I may need to specify individual options when invoking `delta`. For that reason, I think it’s beneficial to source `delta` autocompletion in Bash, ensuring it's available when needed. This does come at the cost of evaluating a command and sourcing its output each time bash starts, but I find the trade-off reasonable (the evaluation should be fast)


