### PR TITLE
re-instantiate mouse support in tmux

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -8,8 +8,8 @@ set -g default-command "${SHELL}"
 # Scroll History
 set -g history-limit 30000
 
-# Make mouse useful again
-setw -g mouse off
+# Enable scrolling in tmux panels with mouse wheel
+set -g mouse on
 
 # Disable status bar
 set -g status off


### PR DESCRIPTION
Haven't fixed the off-by-one cursor selection problem in tmux when using alacritty yet, however rely solely on Ctrb-b [ for scrolling, while sometimes convenient, is somewhat limiting. For single screen selection, i can alwats bypass tmux selection and go straight to alacritty by pressing the shift key, and should be enough for most selections in my case. For selection with scrolling, for now i'm left with no other option than staying with the off-by-one selection issue 