### PR TITLE
tmux shortcut to navigate between windows by name

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -25,3 +25,6 @@ set-option -s escape-time 1
 
 # Lower escape timing from 500ms to 10ms for quicker response when scrolling
 set-option -g repeat-time 10
+
+# Shortcut to reach a window by name
+bind-key g command-prompt -p "Jump to window:" "select-window -t '%%'"


### PR DESCRIPTION
I usually try to avoid as much as possible custom shortcuts, because they are non-standard, and muscle-memory would not be portable to a different computer (eg, remote session etc). however i benefit a lot from being able to navigate between tmux windows by name, so i make an exception to my rule and here i define a custom shortcut 