### PR TITLE
add support for tmuxinator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TASKS=bash stow alacritty gitconfig neovim nix starship tmux vim  vim-config stack agda
+TASKS=bash stow alacritty gitconfig neovim nix starship tmux vim  vim-config stack agda tmuxinator
 VERBOSITY=1
 FLAGS=--no-folding --verbose $(VERBOSITY) --target ~
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ If you want to run it in dry mode, use the `--simulate` option:
 stow --simulate --no-folding --verbose --target ~ <name of the folder>
 ```
 
+## Keep Makefile up to date
+
+When adding a new target, update the list of all targets in the Makefile
+
 ## Why --no-folding?
 
 * For dotfiles placed directly in $HOME (e.g., `.bashrc`, `.gitconfig`), the `--no-folding` flag is redundant and can be omitted.

--- a/nix/.nixpkgs/darwin-configuration.nix
+++ b/nix/.nixpkgs/darwin-configuration.nix
@@ -37,6 +37,7 @@ in
       awscli2
 #     (gradle.override { java = pkgs.jdk17; })
       tmux
+      tmuxinator
       unzip
       curl
       nodejs_latest

--- a/tmuxinator/.config/tmuxinator/workstation.yml
+++ b/tmuxinator/.config/tmuxinator/workstation.yml
@@ -1,0 +1,15 @@
+name: workstation
+
+windows:
+  - main:
+      layout: even-horizontal
+      panes:
+        -
+  - nvim:
+      layout: even-horizontal
+      panes:
+        -
+  - htop:
+      layout: even-horizontal
+      panes:
+        - htop


### PR DESCRIPTION
I'm not sure it's worth adding a tool like tmuxinator, 99% of my time I'm happy just with plain tmux personally. 
tmuxinator gives me just to advantages: prelaunch something like htop in a dedicated window (but let's be honest: i rarely need it), and name two tabs nvim and main by default. Is it worth the cost of adding tmuxinator? I doubt so, but let's give it a go. 

* added tmuxinator to darwin, to install it by default 
* added default ~/.config/tmuxinator/workstation.yml config file (to be installed with stow) 
* added tmuxinator to Makefile for stow 
* updated README of this project to add a warning to update Makefile when adding new stow targets

I think for now the idea is: let's add it, and see how often i use it. Probably never, and in such case i will remove it