### PR TITLE
Jdk 21, htop and macmon in darwin

### DIFF
--- a/nix/.nixpkgs/darwin-configuration.nix
+++ b/nix/.nixpkgs/darwin-configuration.nix
@@ -12,8 +12,8 @@ let
   ];
 
   scalaStuff = with pkgs; [
-      jdk17
-      (sbt.override { jre = pkgs.jdk17; })
+      jdk21
+      (sbt.override { jre = pkgs.jdk21; })
       coursier # for metals
   ];
 
@@ -51,6 +51,8 @@ in
       pkg-config 
       ollama
       llama-cpp
+      htop
+      macmon
     ];
 
   # Use a custom configuration.nix location.


### PR DESCRIPTION
* upgrade JDK from 17 to 21 (LTS) 
* add htop and macmon on darwin

My goal has always been to keep darwin minimal and prefer ephemeral nix-shells. SO, if we need htop the preferred way should be to launch `nix-shell -p htop` only when needed. However, I think they are general purpose tools that make sense to just have always available. 

Why not two PRs instead of 1? Ultimately, i could need to revert htop and macmon, but not jdk! That's a very good question, and the answer i guess is that i was just lazy to do it! 