### PR TITLE
starting point codex profile configuration to run sbt test in sandbox mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ TASKS=bash stow alacritty gitconfig nvim nix starship tmux stack agda rg cargo c
 VERBOSITY=1
 FLAGS=--restow --no-folding --verbose $(VERBOSITY) --target ~
 NIX_UPDATE_INPUTS=nixpkgs nixpkgs-fast darwin home-manager neovim-nightly-overlay rust-overlay llm-agents
+CODEX_CONFIG_FILES=codex/.codex/config.toml codex/.codex/sbt-test.config.toml codex/.codex/with-mcp.config.toml
 
 .PHONY: all $(TASKS) test help nvim-test nvim-test-internal nix-update nix-inputs codex-lock codex-unlock
 
@@ -32,10 +33,10 @@ nix-inputs:
 	@printf '%s\n' $(NIX_UPDATE_INPUTS)
 
 codex-lock:
-	chflags uchg codex/.codex/config.toml
+	chflags uchg $(CODEX_CONFIG_FILES)
 
 codex-unlock:
-	chflags nouchg codex/.codex/config.toml
+	chflags nouchg $(CODEX_CONFIG_FILES)
 
 help:
 	@printf '%s\n' 'Stow targets:'
@@ -46,6 +47,6 @@ help:
 	@printf '  %-14s %s\n' nvim-test 'Run the Neovim test suite inside nix develop'
 	@printf '  %-14s %s\n' nix-update 'Update all nix-darwin flake inputs, or pass INPUTS="nixpkgs darwin" to limit'
 	@printf '  %-14s %s\n' nix-inputs 'List supported nix flake input names'
-	@printf '  %-14s %s\n' codex-lock 'Protect codex/.codex/config.toml with chflags uchg'
-	@printf '  %-14s %s\n' codex-unlock 'Remove uchg protection from codex/.codex/config.toml'
+	@printf '  %-14s %s\n' codex-lock 'Protect tracked Codex config files with chflags uchg'
+	@printf '  %-14s %s\n' codex-unlock 'Remove uchg protection from tracked Codex config files'
 	@printf '  %-14s %s\n' help 'Show available targets'

--- a/codex/.codex/config.toml
+++ b/codex/.codex/config.toml
@@ -1,14 +1,7 @@
 model = "gpt-5.5"
 model_reasoning_effort = "high"
-sandbox_mode = "read-only"
+default_permissions = ":read-only"
 approval_policy = "untrusted"
-
-[sandbox_workspace_write]
-writable_roots = [
-  "/Users/alessandrocandolini/.sbt",
-  "/Users/alessandrocandolini/.ivy2",
-  "/Users/alessandrocandolini/.cache/coursier"
-]
 
 [tui]
 animations=false

--- a/codex/.codex/sbt-test.config.toml
+++ b/codex/.codex/sbt-test.config.toml
@@ -1,0 +1,29 @@
+default_permissions = "sbt-test"
+
+[permissions.sbt-test]
+description = "Workspace write profile for running sbt test with SBT/Coursier caches and Unix sockets."
+extends = ":workspace"
+
+[permissions.sbt-test.filesystem]
+":tmpdir" = "write"
+"/Users/alessandrocandolini/.cache/coursier" = "read"
+"/Users/alessandrocandolini/.ivy2" = "read"
+"/Users/alessandrocandolini/.ivy2/.sbt.ivy.lock" = "write"
+"/Users/alessandrocandolini/.ivy2/exclude_classifiers.lock" = "write"
+"/Users/alessandrocandolini/.sbt/boot" = "write"
+"/Users/alessandrocandolini/.sbt/1.0" = "read"
+"/Users/alessandrocandolini/.sbt/1.0/staging" = "write"
+
+[permissions.sbt-test.network]
+enabled = true
+mode = "limited"
+allow_local_binding = false
+allow_upstream_proxy = false
+
+[permissions.sbt-test.network.domains]
+"localhost" = "allow"
+"127.0.0.1" = "allow"
+"::1" = "allow"
+
+[permissions.sbt-test.network.unix_sockets]
+"/Users/alessandrocandolini/.sbt/1.0/server/**" = "allow"


### PR DESCRIPTION

Permissions can probably be narrowed down even more, but the current configuration seems to be working fine (assuming all 3rd aprty dependencies are already cached locally; there's no external network access, only localhost; unsure why sbt needs access to unix socket also when all dependencies are local) 
