### PR TITLE
Grant tmp write access by default to codex sandbox in default profile

### DIFF
--- a/codex/.codex/config.toml
+++ b/codex/.codex/config.toml
@@ -1,7 +1,14 @@
 model = "gpt-5.5"
 model_reasoning_effort = "high"
-default_permissions = ":read-only"
+default_permissions = "read-only-tmp"
 approval_policy = "untrusted"
+
+[permissions.read-only-tmp]
+description = "Read-only profile with temp-directory writes for local tool cache and lock files."
+extends = ":read-only"
+
+[permissions.read-only-tmp.filesystem]
+":tmpdir" = "write"
 
 [tui]
 animations=false


### PR DESCRIPTION

Slightly unsafe , i'd prefer base profile to only have read access to the entire file system, but maybe /tmp is safe enough
