### PR TITLE
Revert "Never allow codex to make local patches without escalation"

### DIFF
--- a/codex/.codex/sbt-test.config.toml
+++ b/codex/.codex/sbt-test.config.toml
@@ -1,8 +1,8 @@
 default_permissions = "sbt-test"
 
 [permissions.sbt-test]
-description = "Read-only workspace profile for running sbt test with SBT/Coursier caches and Unix sockets."
-extends = ":read-only"
+description = "Workspace write profile for running sbt test with SBT/Coursier caches and Unix sockets."
+extends = ":workspace"
 
 [permissions.sbt-test.filesystem]
 ":tmpdir" = "write"


### PR DESCRIPTION
Reverts alessandrocandolini/dotfiles-public#274

sadly, sbt test would no longer run with this change, as it needs write access to the`target/` folder in a scala project. 

this is frustrating, as ideally i would like the sandbox to prevent the agent from applying patches automatically without my approval, but at the same time there's currently no way to say "allow the target folder in the workspace" in the codex profile config. I could add an alias to launch codex with `--add-dir` but that seems overkilling