### PR TITLE
Allow write on target/ folders for scala projects in sbt-test profile

### DIFF
--- a/codex/.codex/sbt-test.config.toml
+++ b/codex/.codex/sbt-test.config.toml
@@ -1,7 +1,7 @@
 default_permissions = "sbt-test"
 
 [permissions.sbt-test]
-description = "Read-only workspace profile for running sbt test with SBT/Coursier caches and Unix sockets."
+description = "Read-only workspace profile for running sbt test with writable target outputs, SBT/Coursier caches, and Unix sockets."
 extends = ":read-only"
 
 [permissions.sbt-test.filesystem]
@@ -14,6 +14,15 @@ extends = ":read-only"
 "/Users/alessandrocandolini/.sbt/boot" = "write"
 "/Users/alessandrocandolini/.sbt/1.0" = "read"
 "/Users/alessandrocandolini/.sbt/1.0/staging" = "write"
+
+[permissions.sbt-test.filesystem.":workspace_roots"]
+"." = "read"
+"target" = "write"
+"target/**" = "write"
+"project/target" = "write"
+"project/target/**" = "write"
+"project/project/target" = "write"
+"project/project/target/**" = "write"
 
 [permissions.sbt-test.network]
 enabled = true


### PR DESCRIPTION

Otherwise the agent can't run `sbt test` with the current configuration of `sbt-test` profile since the changes in #275 to make the profile :read-only 

However, i'm still not sure what to do and if i wanna revert #275. On one side, #275 means the agent will never ever be able to make changes directly to the app code without escalating to  me, and this is a desirable property; however, on the other side, `sbt test` might trigger (depending on the config of the Scala project) a reformatting of the source code, and that would currently fail! Let's try to see how annoying that is 
